### PR TITLE
Allow copy URL on FNMDebugListingViewController via iOS 11 `UIC…

### DIFF
--- a/FNMNetworkMonitor.podspec
+++ b/FNMNetworkMonitor.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
   spec.name = 'FNMNetworkMonitor'
   spec.module_name = 'FNMNetworkMonitor'
-  spec.version = '9.0.0'
+  spec.version = '9.1.0'
   spec.summary = 'A network monitor'
   spec.homepage = 'https://github.com/Farfetch/network-monitor-ios'
   spec.license = 'MIT'

--- a/NetworkMonitor/Classes/Debug/Controller/FNMDebugListingViewController.swift
+++ b/NetworkMonitor/Classes/Debug/Controller/FNMDebugListingViewController.swift
@@ -40,6 +40,7 @@ final class FNMDebugListingViewController: FNMViewController {
             type(of: self).defaults().set(newSortOrder.rawValue, forKey: SortOrder.key)
         }
     }
+
     private var errorFilterType: ErrorFilterType = .allRequests
 
     // MARK: Lifecycle
@@ -405,6 +406,41 @@ private extension FNMDebugListingViewController {
     }
 }
 
+// MARK: - Private
+
+private extension FNMDebugListingViewController {
+
+    @available(iOS 11.0, *)
+    func makeShareContextualAction(forRowAt indexPath: IndexPath) -> UIContextualAction {
+
+        let action = UIContextualAction(style: .normal, title: nil) { [weak self] (action, swipeButtonView, completion) in
+
+            guard let self = self else {
+
+                return completion(false)
+            }
+
+            if self.filteredRecords.count > indexPath.row,
+               let requestURL = self.filteredRecords[indexPath.row].request.url {
+
+                let ac = UIActivityViewController(activityItems: [requestURL], applicationActivities: nil)
+                self.present(ac, animated: true)
+            }
+
+            completion(true)
+        }
+
+        action.backgroundColor = .systemTeal
+
+        if #available(iOS 13, *) {
+
+            action.image = UIImage(systemName: Constants.exportImage, withConfiguration: nil)
+        }
+
+        return action
+    }
+}
+
 // MARK: - FNMNetworkMonitorObserver
 
 extension FNMDebugListingViewController: FNMNetworkMonitorObserver {
@@ -466,6 +502,14 @@ extension FNMDebugListingViewController: UITableViewDelegate {
             self.navigationController?.pushViewController(detailViewController,
                                                           animated: true)
         }
+    }
+
+    @available(iOS 11.0, *)
+    func tableView(_ tableView: UITableView, leadingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
+
+        return UISwipeActionsConfiguration(actions: [
+            self.makeShareContextualAction(forRowAt: indexPath)
+        ])
     }
 }
 


### PR DESCRIPTION
# PR Details

* This would allow URL sharing on `FNMDebugListingViewController`'s cells with a swipe right, using `UIContextualAction` (iOS 11) and `UIActivityViewController`
* Also using SF Symbols relying on iOS 13, same as it's being used for toolbar icons, for the Share icon

## Description

![Simulator Screen Shot - iPhone 11 Pro - 2020-09-03 at 17 45 52](https://user-images.githubusercontent.com/25558/92144622-dfce1800-ee0e-11ea-8d64-43b190153044.png)

## Motivation and Context

This solves a problem of having to email the full request in order to get the URL from the list

## How Has This Been Tested

* iPhone 8 - iOS 14 beta 6
* iOS 14 Simulator 
* Xcode 12 beta 6

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)