### PR TITLE
Enables cataloging call using the overall identifier

### DIFF
--- a/FNMNetworkMonitor.podspec
+++ b/FNMNetworkMonitor.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
   spec.name = 'FNMNetworkMonitor'
   spec.module_name = 'FNMNetworkMonitor'
-  spec.version = '9.1.0'
+  spec.version = '9.2.0'
   spec.summary = 'A network monitor'
   spec.homepage = 'https://github.com/Farfetch/network-monitor-ios'
   spec.license = 'MIT'

--- a/NetworkMonitor/Classes/Exporter/FNMRecordExporter.swift
+++ b/NetworkMonitor/Classes/Exporter/FNMRecordExporter.swift
@@ -42,7 +42,8 @@ struct FNMRecordExporter {
     }
 
     static func exportRecord(_ record: FNMRecord,
-                                      requestRecords: [FNMHTTPRequestRecord]) {
+                                      requestRecords: [FNMHTTPRequestRecord],
+                                      overallRecords: Bool = false) {
 
         DispatchQueue.global().async {
 
@@ -52,7 +53,8 @@ struct FNMRecordExporter {
                 let currentRunConfigurationFilenameURL = try self.currentRunConfigurationFilenameURL()
 
                 let currentRunSerializableObject = FNMCurrentRunCodableContainer(record: record,
-                                                                                          requestRecords: requestRecords)
+                                                                                          requestRecords: requestRecords,
+                                                                                          overallRecords: overallRecords)
                 try self.encodeObject(currentRunSerializableObject,
                                       fileUrl: currentRunConfigurationFilenameURL)
 

--- a/NetworkMonitor/Classes/Exporter/Records/FNMCurrentRunCodableContainer.swift
+++ b/NetworkMonitor/Classes/Exporter/Records/FNMCurrentRunCodableContainer.swift
@@ -24,13 +24,15 @@ final class FNMCurrentRunCodableContainer: NSObject {
     var nonBlockingRequestNodes: [FNMRequestNode] { return self.matchesContainer?.nonBlockingRequestNodes() ?? [] }
 
     init(record: FNMRecord,
-         requestRecords: [FNMHTTPRequestRecord]) {
+         requestRecords: [FNMHTTPRequestRecord],
+         overallRecords: Bool = false) {
 
         self.record = record
         self.requestRecords = requestRecords
 
         self.matchesContainer = RecordNodeMatchesContainer(requestRecords: self.requestRecords,
-                                                           and: self.record)
+                                                           and: self.record,
+                                                           overallRecords: overallRecords)
     }
 }
 
@@ -42,9 +44,9 @@ private struct RecordNodeMatchesContainer {
     let matches: [FNMRecordNodeMatch]
 
     init?(requestRecords: [FNMHTTPRequestRecord],
-          and record: FNMRecord) {
+          and record: FNMRecord, overallRecords: Bool = false) {
 
-        let callElement = record.timestamps["firstPartyAPISetup"]
+        let callElement = record.timestamps[overallRecords ? "overall" : "firstPartyAPISetup"]
 
         guard let callsStart = callElement?.start,
             let callsEnd = callElement?.end,

--- a/NetworkMonitor/Classes/FNMNetworkMonitor.swift
+++ b/NetworkMonitor/Classes/FNMNetworkMonitor.swift
@@ -158,11 +158,11 @@ public final class FNMNetworkMonitor: NSObject {
     }
 
     /// Export the data
-    public func exportData(record: FNMRecord) {
+    public func exportData(record: FNMRecord, overallRecords: Bool = false) {
 
         self.recordsSyncQueue.async {
 
-            FNMRecordExporter.exportRecord(record, requestRecords: Array(self.records.values))
+            FNMRecordExporter.exportRecord(record, requestRecords: Array(self.records.values), overallRecords: overallRecords)
         }
     }
 


### PR DESCRIPTION
# PR Details

This PR allows NetworkMonitor to use the overall identifier to catalog calls
