### PR TITLE
Change Available Profile in JSON Report. 

### DIFF
--- a/FNMNetworkMonitor.podspec
+++ b/FNMNetworkMonitor.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
   spec.name = 'FNMNetworkMonitor'
   spec.module_name = 'FNMNetworkMonitor'
-  spec.version = '10.0.0'
+  spec.version = '11.0.0'
   spec.summary = 'A network monitor'
   spec.homepage = 'https://github.com/Farfetch/network-monitor-ios'
   spec.license = 'MIT'

--- a/NetworkMonitor/Classes/Exporter/RequestRecord/FNMHTTPRequestRecord+Codable.swift
+++ b/NetworkMonitor/Classes/Exporter/RequestRecord/FNMHTTPRequestRecord+Codable.swift
@@ -33,6 +33,7 @@ extension FNMHTTPRequestRecord: Encodable {
         case startTimestamp = "startedAt"
         case endTimestamp = "endedAt"
         case timeSpent = "timeSpent"
+        case profile = "profile"
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -44,6 +45,7 @@ extension FNMHTTPRequestRecord: Encodable {
         try container.encode(self.endTimestamp, forKey: .endTimestamp)
         try container.encode(self.conclusion?.displayRepresentation(), forKey: .conclusion)
         try container.encode(self.timeSpent, forKey: .timeSpent)
+        try container.encode(self.profile, forKey: .profile)
     }
 }
 

--- a/NetworkMonitor/Classes/Exporter/RequestRecord/FNMHTTPRequestRecordCodableContainer.swift
+++ b/NetworkMonitor/Classes/Exporter/RequestRecord/FNMHTTPRequestRecordCodableContainer.swift
@@ -29,12 +29,6 @@ private extension FNMHTTPRequestRecordCodableContainer {
 
         return type(of: self).totalTimeSpend(from: records)
     }
-
-    var availableProfiles: [FNMProfile] {
-
-        return records.compactMap { return FNMProfile(record: $0) }
-    }
-
 }
 
 private extension FNMHTTPRequestRecordCodableContainer {
@@ -62,7 +56,6 @@ extension FNMHTTPRequestRecordCodableContainer: Encodable {
     enum CodingKeys: String, CodingKey {
 
         case records
-        case availableProfiles
         case totalRecords
         case totalTimeSpend
     }
@@ -73,6 +66,5 @@ extension FNMHTTPRequestRecordCodableContainer: Encodable {
         try container.encode(self.totalRecords, forKey: .totalRecords)
         try container.encode(self.totalTimeSpend, forKey: .totalTimeSpend)
         try container.encode(self.records, forKey: .records)
-        try container.encode(self.availableProfiles, forKey: .availableProfiles)
     }
 }

--- a/NetworkMonitor/Classes/URLProtocol/FNMHTTPRequestRecord.swift
+++ b/NetworkMonitor/Classes/URLProtocol/FNMHTTPRequestRecord.swift
@@ -56,6 +56,11 @@ final public class FNMHTTPRequestRecord: NSObject {
         return endTimestamp.timeIntervalSince1970 - self.startTimestamp.timeIntervalSince1970
     }
 
+    public var profile: FNMProfile? {
+
+        return FNMProfile(record: self)
+    }
+
     public init(key: HTTPRequestRecordKey,
                 request: NSURLRequest,
                 startTimestamp: Date) {


### PR DESCRIPTION
# PR Details

In this PR, I've made a simple change in how the JSON output file (report) is built, to make the data computation easier and not depend on obscure rules (like indexing comparison)

## Description

- Removed availableProfiles section from `FNMHTTPRequestRecordCodableContainer`
- Added profile into `FNMHTTPRequestRecord`

## Motivation and Context

Currently, the profiles are directly associated with the records but on the JSON file report, we don't have this relationship. 
The fields `records` and the `availableProfiles` apparently don't have any link so, it's impossible to define what profile was used in a record so, if we try to track for example the "header" of a record, it is impossible (for sure) to find out wich profile was used in a call. 

To solve this problem I've thought the best approach is to embed the `profile` into the `record` so we have a direct relation. 

## Types of changes

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the [CONTRIBUTING](CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.


### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)