### PR TITLE
Fixed Xcode 12.5 Warnings Related to Protocol Composition

### DIFF
--- a/FNMNetworkMonitor.podspec
+++ b/FNMNetworkMonitor.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
   spec.name = 'FNMNetworkMonitor'
   spec.module_name = 'FNMNetworkMonitor'
-  spec.version = '11.4.1'
+  spec.version = '11.5.0'
   spec.summary = 'A network monitor'
   spec.homepage = 'https://github.com/Farfetch/network-monitor-ios'
   spec.license = 'MIT'

--- a/NetworkMonitor.xcodeproj/project.pbxproj
+++ b/NetworkMonitor.xcodeproj/project.pbxproj
@@ -389,7 +389,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 1130;
-				LastUpgradeCheck = 1200;
+				LastUpgradeCheck = 1250;
 				ORGANIZATIONNAME = Farfetch;
 				TargetAttributes = {
 					F793CA4C1F9E361900AA9C41 = {

--- a/NetworkMonitor.xcodeproj/xcshareddata/xcschemes/NetworkMonitor.xcscheme
+++ b/NetworkMonitor.xcodeproj/xcshareddata/xcschemes/NetworkMonitor.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1200"
+   LastUpgradeVersion = "1250"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/NetworkMonitor/Classes/FNMNetworkMonitor.swift
+++ b/NetworkMonitor/Classes/FNMNetworkMonitor.swift
@@ -10,7 +10,7 @@ import Foundation
 import UIKit
 
 @objc
-public protocol FNMNetworkMonitorObserver: class {
+public protocol FNMNetworkMonitorObserver: AnyObject {
 
     func recordsUpdated(records: [FNMHTTPRequestRecord])
 }

--- a/NetworkMonitor/Classes/URLProtocol/FNMNetworkMonitorURLProtocol+Protocols.swift
+++ b/NetworkMonitor/Classes/URLProtocol/FNMNetworkMonitorURLProtocol+Protocols.swift
@@ -25,4 +25,4 @@ protocol FNMNetworkMonitorURLProtocolDataSourceProfile {
     func bumpUses(for profileResponseIdentifier: String)
 }
 
-protocol FNMNetworkMonitorURLProtocolDataSource: class, FNMNetworkMonitorURLProtocolDataSourceRecord, FNMNetworkMonitorURLProtocolDataSourceProfile { }
+protocol FNMNetworkMonitorURLProtocolDataSource: AnyObject, FNMNetworkMonitorURLProtocolDataSourceRecord, FNMNetworkMonitorURLProtocolDataSourceProfile { }


### PR DESCRIPTION
# PR Details

This PR fixes the warnings related to protocol composition that started to appear in Xcode 12.5. Also update the migration checks.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)