### PR TITLE
Add URLSession invalidate

### DIFF
--- a/FNMNetworkMonitor.podspec
+++ b/FNMNetworkMonitor.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
   spec.name = 'FNMNetworkMonitor'
   spec.module_name = 'FNMNetworkMonitor'
-  spec.version = '11.5.0'
+  spec.version = '11.6.0'
   spec.summary = 'A network monitor'
   spec.homepage = 'https://github.com/Farfetch/network-monitor-ios'
   spec.license = 'MIT'

--- a/FNMNetworkMonitor.podspec
+++ b/FNMNetworkMonitor.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
   spec.name = 'FNMNetworkMonitor'
   spec.module_name = 'FNMNetworkMonitor'
-  spec.version = '11.6.0'
+  spec.version = '11.5.1'
   spec.summary = 'A network monitor'
   spec.homepage = 'https://github.com/Farfetch/network-monitor-ios'
   spec.license = 'MIT'

--- a/NetworkMonitor/Classes/URLProtocol/FNMNetworkMonitorURLProtocol.swift
+++ b/NetworkMonitor/Classes/URLProtocol/FNMNetworkMonitorURLProtocol.swift
@@ -211,6 +211,8 @@ extension FNMNetworkMonitorURLProtocol: URLSessionDataDelegate {
 
         self.handleDataTaskCompletion(response: task.response,
                                       error: error)
+
+        session.finishTasksAndInvalidate()
     }
 }
 


### PR DESCRIPTION
# PR Details

This PR is adding an URLSession invalidate to prevent abandoned memory allocations.

## Motivation and Context

Every connection intercepted by network monitor is creating a new URLSession, which will be abandoned later on, but not entirely deallocated, so to prevent this situation, we must call the URLSession invalidate explicitly.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)