### PR TITLE
Add toggle to save media payload and upload/download information

### DIFF
--- a/FNMNetworkMonitor.podspec
+++ b/FNMNetworkMonitor.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
   spec.name = 'FNMNetworkMonitor'
   spec.module_name = 'FNMNetworkMonitor'
-  spec.version = '11.6.0'
+  spec.version = '11.7.0'
   spec.summary = 'A network monitor'
   spec.homepage = 'https://github.com/Farfetch/network-monitor-ios'
   spec.license = 'MIT'

--- a/NetworkMonitor/Classes/Debug/Controller/DebugDetailBodyViewController.swift
+++ b/NetworkMonitor/Classes/Debug/Controller/DebugDetailBodyViewController.swift
@@ -87,7 +87,7 @@ private extension DebugDetailBodyViewController {
         switch self.recordBodyDetailInfo.body.contentType {
         
         case .text(_):
-            
+
             self.view.addSubview(self.textView)
 
             self.textView.translatesAutoresizingMaskIntoConstraints = false

--- a/NetworkMonitor/Classes/Debug/Controller/DebugDetailBodyViewController.swift
+++ b/NetworkMonitor/Classes/Debug/Controller/DebugDetailBodyViewController.swift
@@ -15,7 +15,8 @@ final class DebugDetailBodyViewController: UIViewController, HighlightReloadable
     let recordBodyDetailInfo: RecordBodyDetailInfo
 
     private let titleLabel = UILabel()
-    private let textView = UITextView()
+    private lazy var textView = UITextView()
+    private lazy var imageView = UIImageView()
 
     var highlight: String = ""
 
@@ -56,17 +57,13 @@ private extension DebugDetailBodyViewController {
     // MARK: - Constants
     enum Constants {
 
-           static let goldColor = UIColor(red: 196.0, green: 170.0, blue: 132.0, alpha: 1.0)
-           static let titleLabelFontSize: CGFloat = 15.0
+           static let goldColor = UIColor(red: 196.0/255, green: 170.0/255, blue: 132.0/255, alpha: 1.0)
+           static let titleLabelMinHeight: CGFloat = 25.0
            static let textViewFontSize: CGFloat = 14.0
     }
 
     // MARK: - Layout Configuration
     func configureViews() {
-
-        self.view.addSubview(self.titleLabel)
-        self.view.addSubview(self.textView)
-        self.textView.backgroundColor = .white
 
         let guide: UILayoutGuide
 
@@ -79,60 +76,76 @@ private extension DebugDetailBodyViewController {
             guide = self.view.readableContentGuide
         }
 
+        self.view.addSubview(self.titleLabel)
+
         self.titleLabel.translatesAutoresizingMaskIntoConstraints = false
         self.titleLabel.topAnchor.constraint(equalTo: guide.topAnchor).isActive = true
         self.titleLabel.leadingAnchor.constraint(equalTo: guide.leadingAnchor).isActive = true
         self.titleLabel.trailingAnchor.constraint(equalTo: guide.trailingAnchor).isActive = true
+        self.titleLabel.heightAnchor.constraint(greaterThanOrEqualToConstant: Constants.titleLabelMinHeight).isActive = true
 
-        self.textView.translatesAutoresizingMaskIntoConstraints = false
-        self.textView.topAnchor.constraint(equalTo: titleLabel.bottomAnchor).isActive = true
-        self.textView.bottomAnchor.constraint(equalTo: guide.bottomAnchor).isActive = true
-        self.textView.leadingAnchor.constraint(equalTo: guide.leadingAnchor).isActive = true
-        self.textView.trailingAnchor.constraint(equalTo: guide.trailingAnchor).isActive = true
+        switch self.recordBodyDetailInfo.body.contentType {
+        
+        case .text(_):
+            
+            self.view.addSubview(self.textView)
 
-        self.textView.isEditable = false
+            self.textView.translatesAutoresizingMaskIntoConstraints = false
+            self.textView.topAnchor.constraint(equalTo: titleLabel.bottomAnchor).isActive = true
+            self.textView.bottomAnchor.constraint(equalTo: guide.bottomAnchor).isActive = true
+            self.textView.leadingAnchor.constraint(equalTo: guide.leadingAnchor).isActive = true
+            self.textView.trailingAnchor.constraint(equalTo: guide.trailingAnchor).isActive = true
+
+        case .image(_):
+
+            self.view.addSubview(self.imageView)
+
+            self.imageView.translatesAutoresizingMaskIntoConstraints = false
+            self.imageView.topAnchor.constraint(equalTo: titleLabel.bottomAnchor).isActive = true
+            self.imageView.bottomAnchor.constraint(equalTo: guide.bottomAnchor).isActive = true
+            self.imageView.leadingAnchor.constraint(equalTo: guide.leadingAnchor).isActive = true
+            self.imageView.trailingAnchor.constraint(equalTo: guide.trailingAnchor).isActive = true
+        }
 
         self.reloadText()
     }
 
     func reloadText() {
+        
+        switch self.recordBodyDetailInfo.body.contentType {
+        
+        case .text(let data):
 
-        let titleAttributedText = NSMutableAttributedString(string: self.recordBodyDetailInfo.body.title)
-        let style = NSMutableParagraphStyle()
-        style.alignment = .natural
+            self.titleLabel.text = self.recordBodyDetailInfo.body.title
 
-        let titleAttributes: [NSAttributedString.Key: Any] = [.font: UIFont.systemFont(ofSize: Constants.titleLabelFontSize),
-                                                              .kern: 0.0,
-                                                              .baselineOffset: 0.0,
-                                                              .foregroundColor: UIColor.black,
-                                                              .paragraphStyle: style]
+            self.textView.isEditable = false
+            self.textView.backgroundColor = .white
 
-        titleAttributedText.addAttributes(titleAttributes, range: NSRange(location: 0, length: titleAttributedText.string.count))
+            let textViewAttributedText = NSMutableAttributedString(string: data)
 
-        NSString(string: titleAttributedText.string).rangesOfSubstring(NSString(string: self.highlight)).forEach {
+            let textViewAttributes: [NSAttributedString.Key: Any] = [.font: UIFont.boldSystemFont(ofSize: Constants.textViewFontSize),
+                                                                     .kern: 0.0,
+                                                                     .baselineOffset: 0.0,
+                                                                     .foregroundColor: UIColor.black]
 
-            titleAttributedText.addAttributes([.backgroundColor: Constants.goldColor], range: $0)
-        }
+            textViewAttributedText.addAttributes(textViewAttributes, range: NSRange(location: 0, length: textViewAttributedText.string.count))
 
-        self.textView.attributedText = titleAttributedText
+            if self.highlight.count > 0 {
 
-        let textViewAttributedText = NSMutableAttributedString(string: self.recordBodyDetailInfo.body.subtitle)
+                NSString(string: textViewAttributedText.string).rangesOfSubstring(NSString(string: self.highlight)).forEach {
 
-        let textViewAttributes: [NSAttributedString.Key: Any] = [.font: UIFont.boldSystemFont(ofSize: Constants.textViewFontSize),
-                                                                 .kern: 0.0,
-                                                                 .baselineOffset: 0.0,
-                                                                 .foregroundColor: UIColor.black]
-
-        textViewAttributedText.addAttributes(textViewAttributes, range: NSRange(location: 0, length: textViewAttributedText.string.count))
-
-        if self.highlight.count > 0 {
-
-            NSString(string: textViewAttributedText.string).rangesOfSubstring(NSString(string: self.highlight)).forEach {
-
-                textViewAttributedText.addAttributes([.backgroundColor: Constants.goldColor], range: $0)
+                    textViewAttributedText.addAttributes([.backgroundColor: Constants.goldColor], range: $0)
+                }
             }
-        }
 
-        self.textView.attributedText = textViewAttributedText
+            self.textView.attributedText = textViewAttributedText
+            
+        case .image(let data):
+
+            self.titleLabel.text = "\(self.recordBodyDetailInfo.body.title) Image (\(Int(data.size.width))x\(Int(data.size.height)))"
+
+            self.imageView.contentMode = .scaleAspectFit
+            self.imageView.image = data
+        }
     }
 }

--- a/NetworkMonitor/Classes/Debug/Controller/FNMDebugListingViewController.swift
+++ b/NetworkMonitor/Classes/Debug/Controller/FNMDebugListingViewController.swift
@@ -31,6 +31,7 @@ final class FNMDebugListingViewController: FNMViewController {
     let tableView = UITableView(frame: .zero,
                                 style: .plain)
     private let searchBar = UISearchBar()
+    private let statusLabel = UILabel()
 
     private var sortOrder: SortOrder {
         get {
@@ -114,6 +115,9 @@ private extension FNMDebugListingViewController {
         static let sortImage = "arrow.up.arrow.down"
         static let errorImage = "exclamationmark.triangle.fill"
         static let resetImage = "trash"
+
+        static let statUpArrowUnicode = "\u{2191}"
+        static let statDownArrowUnicode = "\u{2193}"
     }
 
     func configureViews() {
@@ -172,6 +176,9 @@ private extension FNMDebugListingViewController {
 
     func configureTableView() {
 
+        self.statusLabel.backgroundColor = .lightGray
+        self.statusLabel.textAlignment = .center
+
         self.searchBar.delegate = self
         self.searchBar.placeholder = Constants.searchPlaceholderTitle
         self.searchBar.barTintColor = .white
@@ -190,6 +197,7 @@ private extension FNMDebugListingViewController {
 
         self.view.addSubview(self.searchBar)
         self.view.addSubview(self.tableView)
+        self.view.addSubview(self.statusLabel)
 
         let superviewGuide: UILayoutGuide
 
@@ -209,9 +217,14 @@ private extension FNMDebugListingViewController {
 
         self.tableView.translatesAutoresizingMaskIntoConstraints = false
         self.tableView.topAnchor.constraint(equalTo: self.searchBar.bottomAnchor).isActive = true
-        self.tableView.bottomAnchor.constraint(equalTo: superviewGuide.bottomAnchor).isActive = true
+        self.tableView.bottomAnchor.constraint(equalTo: self.statusLabel.topAnchor).isActive = true
         self.tableView.leadingAnchor.constraint(equalTo: superviewGuide.leadingAnchor).isActive = true
         self.tableView.trailingAnchor.constraint(equalTo: superviewGuide.trailingAnchor).isActive = true
+        
+        self.statusLabel.translatesAutoresizingMaskIntoConstraints = false
+        self.statusLabel.leadingAnchor.constraint(equalTo: superviewGuide.leadingAnchor).isActive = true
+        self.statusLabel.trailingAnchor.constraint(equalTo: superviewGuide.trailingAnchor).isActive = true
+        self.statusLabel.bottomAnchor.constraint(equalTo: superviewGuide.bottomAnchor).isActive = true
     }
 }
 
@@ -245,11 +258,21 @@ private extension FNMDebugListingViewController {
         return self.searchBar.text?.trimmingCharacters(in: .whitespacesAndNewlines) != "" ? self.searchBar.text : nil
     }
 
+    func updateStatus() {
+
+        let count = FNMNetworkMonitor.shared.records.count
+        let requestSize = FNMNetworkMonitor.shared.totalRequestSize.byteString
+        let responseSize = FNMNetworkMonitor.shared.totalResponseSize.byteString
+
+        self.statusLabel.text = "(\(count))  \(Constants.statUpArrowUnicode) \(requestSize)  \(Constants.statDownArrowUnicode) \(responseSize)"
+    }
+
     func updateAllRecords(to newAllRecords: [FNMHTTPRequestRecord]) {
 
         self.allRecords = newAllRecords.sorted { $0.startTimestamp.timeIntervalSince1970 < $1.startTimestamp.timeIntervalSince1970 }
 
         self.updateFilteredValues()
+        self.updateStatus()
     }
 
     func updateFilteredValues() {

--- a/NetworkMonitor/Classes/Debug/View/FNMDebugSummaryTableViewCell.swift
+++ b/NetworkMonitor/Classes/Debug/View/FNMDebugSummaryTableViewCell.swift
@@ -67,6 +67,8 @@ extension FNMDebugSummaryTableViewCell {
         static let padding: CGFloat = 4.0
         static let negativePadding: CGFloat = Constants.padding * -1
         static let timeUnit = "ms"
+        static let statUpArrowUnicode = "\u{2191}"
+        static let statDownArrowUnicode = "\u{2193}"
         static let downArrowUnicode = "\u{25BC}"
         static let emSpaceUnicode = "\u{2003}"
         static let enSpaceUnicode = "\u{2002}"
@@ -240,7 +242,14 @@ extension FNMDebugSummaryTableViewCell {
 
         guard let requestURL = requestRecord.request.url else { return "" }
 
-        var text = requestURL.absoluteString
+        let requestSize = requestRecord.requestSize.byteString
+        let responseSize = requestRecord.responseSize.byteString
+
+        var text = """
+            \(Constants.statUpArrowUnicode) \(requestSize) \(Constants.statDownArrowUnicode) \(responseSize)
+        
+            \(requestURL.absoluteString)
+        """
 
         if let conclusion = requestRecord.conclusion,
             case FNMHTTPRequestRecordConclusionType.redirected(let newRequest) = conclusion,

--- a/NetworkMonitor/Classes/Extension/FNMAdditions.swift
+++ b/NetworkMonitor/Classes/Extension/FNMAdditions.swift
@@ -171,6 +171,30 @@ public extension Decodable {
     }
 }
 
+extension Int {
+
+    var byteString: String {
+
+        return ByteCountFormatter.string(fromByteCount: Int64(self), countStyle: .memory)
+    }
+}
+
+extension URLRequest {
+    
+    var contentLength: Int {
+
+        return Int(self.allHTTPHeaderFields?["Content-Length"] ?? "") ?? 0
+    }
+}
+
+extension URLResponse {
+
+    var isImage: Bool {
+
+        return self.mimeType?.hasPrefix("image") ?? false
+    }
+}
+
 // Profile Matching
 extension NSURLRequest {
 

--- a/NetworkMonitor/Classes/FNMNetworkMonitor.swift
+++ b/NetworkMonitor/Classes/FNMNetworkMonitor.swift
@@ -37,6 +37,12 @@ public final class FNMNetworkMonitor: NSObject {
     @objc
     public private(set) var records = [HTTPRequestRecordKey: FNMHTTPRequestRecord]()
 
+    /// The sum of all recorded request payload sizes
+    public private(set) var totalRequestSize = 0
+
+    /// The sum of all recorded response payload sizes
+    public private(set) var totalResponseSize = 0
+
     /// The profiles used for record matching. Can be edited
     @objc
     public private(set) var profiles = [FNMProfile]()
@@ -76,6 +82,13 @@ public final class FNMNetworkMonitor: NSObject {
         return FNMNetworkMonitorURLProtocol.active
     }
 
+    /// Configure if media payload will be recorded (default is true)
+    @objc
+    public func recordMediaPayload(value: Bool) {
+
+        FNMNetworkMonitorURLProtocol.recordMediaPayload = value
+    }
+
     /// Reset the current state
     ///
     /// - Parameter completion: a completion
@@ -86,6 +99,8 @@ public final class FNMNetworkMonitor: NSObject {
 
             self.records.removeAll()
             self.profilesUsageMap.removeAll()
+            self.totalRequestSize = 0
+            self.totalResponseSize = 0
 
             self.reportRecordsChange(completion: completion)
         }
@@ -282,6 +297,8 @@ extension FNMNetworkMonitor: FNMNetworkMonitorURLProtocolDataSource {
         self.recordsSyncQueue.async {
 
             self.records[requestRecord.key] = requestRecord
+            self.totalRequestSize += requestRecord.requestSize
+            self.totalResponseSize += requestRecord.responseSize
 
             self.reportRecordsChange(completion: completion)
         }

--- a/NetworkMonitor/Classes/FNMNetworkMonitor.swift
+++ b/NetworkMonitor/Classes/FNMNetworkMonitor.swift
@@ -84,7 +84,7 @@ public final class FNMNetworkMonitor: NSObject {
 
     /// Configure if media payload will be recorded (default is true)
     @objc
-    public func recordMediaPayload(value: Bool) {
+    public func recordMediaPayload(_ value: Bool) {
 
         FNMNetworkMonitorURLProtocol.recordMediaPayload = value
     }

--- a/NetworkMonitor/Classes/URLProtocol/FNMHTTPRequestRecord.swift
+++ b/NetworkMonitor/Classes/URLProtocol/FNMHTTPRequestRecord.swift
@@ -50,6 +50,9 @@ final public class FNMHTTPRequestRecord: NSObject {
     public var endTimestamp: Date?
     public var conclusion: FNMHTTPRequestRecordConclusionType?
 
+    public var requestSize = 0
+    public var responseSize = 0
+
     public var timeSpent: TimeInterval? {
 
         guard let endTimestamp = self.endTimestamp else { return nil }

--- a/NetworkMonitor/Classes/URLProtocol/FNMNetworkMonitorURLProtocol.swift
+++ b/NetworkMonitor/Classes/URLProtocol/FNMNetworkMonitorURLProtocol.swift
@@ -327,11 +327,11 @@ extension FNMNetworkMonitorURLProtocol {
 
             self.requestRecord?.responseSize = self.dataDownloaded?.count ?? 0
 
-            let shouldSkipMedia = Self.recordMediaPayload == false && response?.isImage == true
+            let shouldSkipData = Self.recordMediaPayload == false && response?.isImage == true
 
             self.concludeRecordIfNeeded(conclusion: .completed(URLProtocolLoadState: self.loadState,
                                                                response: response as? HTTPURLResponse,
-                                                               data: shouldSkipMedia ? nil : self.dataDownloaded))
+                                                               data: shouldSkipData ? nil : self.dataDownloaded))
 
             self.client?.urlProtocolDidFinishLoading(self)
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,14 @@ Finally, you can turn on the passive export and the requests will be exported to
 FNMNetworkMonitor.shared.passiveExportPreference = FNMRecordExporterPreference.on(setting: .unlimited)
 ```
 
+## Media payload recording
+
+If you want to allocate less memory while using network monitor, you can disable media paylod recording:
+
+```swift
+FNMNetworkMonitor.shared.recordMediaPayload(false)
+```
+
 ## Sample app
 
 The project contains a sample app where you can test the tool. You can run the Sample Target Scheme in `NetworkMonitor.xcworkspace` to see a working example of the framework.

--- a/Tests/NetworkMonitorDebugUITests.swift
+++ b/Tests/NetworkMonitorDebugUITests.swift
@@ -60,17 +60,26 @@ class NetworkMonitorDebugUITests: NetworkMonitorUnitTests {
 
                 XCTAssertEqual(self.networkMonitor.records.count, 1)
                 XCTAssertEqual(debugDetailViewController.requestBodyViewController.recordBodyDetailInfo.body.title, "Request Body")
-                XCTAssertEqual(debugDetailViewController.requestBodyViewController.recordBodyDetailInfo.body.subtitle, "N/A")
+                
+                if case let .text(text) = debugDetailViewController.requestBodyViewController.recordBodyDetailInfo.body.contentType {
+
+                    XCTAssertEqual(text, "N/A")
+                }
+                
                 XCTAssertEqual(debugDetailViewController.headersViewController.recordHeaderDetailInfo.requestHeaders.first?.title, "HeaderA")
                 XCTAssertEqual(debugDetailViewController.headersViewController.recordHeaderDetailInfo.requestHeaders.first?.subtitle, "ValueA")
                 XCTAssertEqual(debugDetailViewController.responseBodyViewController.recordBodyDetailInfo.body.title, "Response")
-                XCTAssertEqual(debugDetailViewController.responseBodyViewController.recordBodyDetailInfo.body.subtitle, """
-                {
-                    fieldA = valueA;
-                    fieldB = valueB;
-                }
-                ""","")
 
+                if case let .text(text) = debugDetailViewController.responseBodyViewController.recordBodyDetailInfo.body.contentType {
+
+                    XCTAssertEqual(text, """
+                    {
+                        fieldA = valueA;
+                        fieldB = valueB;
+                    }
+                    ""","")
+                }
+    
             } else {
 
                 XCTFail("Should have record")


### PR DESCRIPTION
# PR Details

![Simulator Screen Shot - iPhone 11 Pro - 2021-06-07 at 10 29 12](https://user-images.githubusercontent.com/936413/121032490-394ee300-c7a3-11eb-8206-f345365860ad.png)
![Simulator Screen Shot - iPhone 11 Pro - 2021-06-07 at 10 29 05](https://user-images.githubusercontent.com/936413/121032493-3b18a680-c7a3-11eb-9f5b-0cbf368a3de0.png)



- Adding upload/download size information for each request
- Adding upload/download total size information
- Adding toggle to save media payload in memory
- Adding support for image preview on debug view
- Fixing request/response missing title
- Fixing text color filter on debug view

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)