### PR TITLE
Adds ignore list capability to be able to filter out undesired domains

### DIFF
--- a/FNMNetworkMonitor.podspec
+++ b/FNMNetworkMonitor.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
   spec.name = 'FNMNetworkMonitor'
   spec.module_name = 'FNMNetworkMonitor'
-  spec.version = '11.7.0'
+  spec.version = '11.8.0'
   spec.summary = 'A network monitor'
   spec.homepage = 'https://github.com/Farfetch/network-monitor-ios'
   spec.license = 'MIT'

--- a/NetworkMonitor/Classes/FNMNetworkMonitor.swift
+++ b/NetworkMonitor/Classes/FNMNetworkMonitor.swift
@@ -59,6 +59,8 @@ public final class FNMNetworkMonitor: NSObject {
     /// Date used for internal logic
     let referenceDate = Date()
 
+    var ignoredDomains: [String] = []
+
     /// Start monitoring the network
     @objc
     public func startMonitoring() {
@@ -114,7 +116,7 @@ public final class FNMNetworkMonitor: NSObject {
 
         self.observers = self.observers.filter { $0.innerObserver != nil }
 
-        if self.observers.contains(where: { (wrapper) -> Bool in return observer === wrapper.innerObserver }) == false {
+        if self.observers.contains(where: { observer === $0.innerObserver }) == false {
 
             let wrapper = NetworkMonitorObserverWrapper()
             wrapper.innerObserver = observer
@@ -129,7 +131,7 @@ public final class FNMNetworkMonitor: NSObject {
     @objc
     public func unsubscribe(observer: FNMNetworkMonitorObserver) {
 
-        if let index = self.observers.firstIndex(where: { (wrapper) -> Bool in return observer === wrapper.innerObserver }) {
+        if let index = self.observers.firstIndex(where: { observer === $0.innerObserver }) {
 
             self.observers.remove(at: index)
         }
@@ -248,6 +250,12 @@ public final class FNMNetworkMonitor: NSObject {
 
         config.protocolClasses = customProtocolClasses
     }
+
+    @objc
+    public func configure(ignoredDomains: [String]) {
+
+        self.ignoredDomains = ignoredDomains
+    }
 }
 
 private extension FNMNetworkMonitor {
@@ -285,6 +293,11 @@ extension FNMNetworkMonitor {
 }
 
 extension FNMNetworkMonitor: FNMNetworkMonitorURLProtocolDataSource {
+
+    func shouldIgnoreRequest(with url: URL) -> Bool {
+
+        self.ignoredDomains.contains(where: { url.absoluteString.contains($0) } )
+    }
 
     func requestRecord(for key: HTTPRequestRecordKey) -> FNMHTTPRequestRecord? {
 

--- a/NetworkMonitor/Classes/URLProtocol/FNMNetworkMonitorURLProtocol+Protocols.swift
+++ b/NetworkMonitor/Classes/URLProtocol/FNMNetworkMonitorURLProtocol+Protocols.swift
@@ -5,12 +5,16 @@
 // This source code is licensed under the MIT-style license found in the
 // LICENSE file in the root directory of this source tree.
 //
+
+import Foundation
+
 typealias HTTPRequestRecordSetterCompletion = () -> (Void)
 public typealias HTTPRequestRecordKey = String
 
 protocol FNMNetworkMonitorURLProtocolDataSourceRecord {
 
     func requestRecord(for key: HTTPRequestRecordKey) -> FNMHTTPRequestRecord?
+    func shouldIgnoreRequest(with url: URL) -> Bool
 
     func setRequestRecord(requestRecord: FNMHTTPRequestRecord,
                           completion: @escaping HTTPRequestRecordSetterCompletion)

--- a/NetworkMonitor/Classes/URLProtocol/FNMNetworkMonitorURLProtocol.swift
+++ b/NetworkMonitor/Classes/URLProtocol/FNMNetworkMonitorURLProtocol.swift
@@ -389,6 +389,9 @@ private extension FNMNetworkMonitorURLProtocol {
         guard let rawScheme = url.scheme,
             AllowedURLScheme.isSchemeAllowed(urlScheme: rawScheme) else { return false }
 
+        // Avoid monitoring the url belongs to an ignored domain
+        guard FNMNetworkMonitorURLProtocol.dataSource?.shouldIgnoreRequest(with: url) == false else { return false }
+
         // Avoid monitoring already monitored requests
         guard URLProtocol.property(forKey: GeneralConstants.tagKey, in: request) == nil else { return false }
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,16 @@ FNMNetworkMonitor.shared.configure(profiles: profiles)
 FNMNetworkMonitor.shared.startMonitoring()
 ```
 
+You can also ignore domains using:
+
+```swift
+FNMNetworkMonitor.shared.configure(ignoredDomains: ["somedomain.com"])
+``` 
+
+This won't record nor intercept requests for this domain.
+
+
+
 Make sure to follow steps 1, 2 or 3, depending on the URLSession that runs that particular request.
 
 ### How to see it all

--- a/Sample/Sample/ViewController.swift
+++ b/Sample/Sample/ViewController.swift
@@ -19,7 +19,7 @@ final class ViewController: UIViewController {
 
         static let robotURL = "https://www.alphabet.com/robots.txt"
         static let errorURL = "https://www.oh.the.humanity/error"
-
+        static let chuckNorrisURL = "https://api.chucknorris.io/jokes/random"
         static let randomImageURL = "https://picsum.photos/500?random"
     }
 
@@ -28,6 +28,7 @@ final class ViewController: UIViewController {
         case imageRedirect
         case error
         case robot
+        case chuckNorris
 
         static var random: TestRequest {
 
@@ -57,6 +58,7 @@ final class ViewController: UIViewController {
                                           repeats: true,
                                           block: { _ in self.fire() })
 
+        FNMNetworkMonitor.shared.configure(ignoredDomains: ["https://api.chucknorris.io"])
         FNMNetworkMonitor.shared.showDebugListingViewController(presentingNavigationController: self.navigationController)
     }
 
@@ -124,6 +126,9 @@ final class ViewController: UIViewController {
 
         case .robot:
             URLSession.shared.dataTask(with: URL(string: Constants.robotURL)!).resume()
+
+        case .chuckNorris:
+            URLSession.shared.dataTask(with: URL(string: Constants.chuckNorrisURL)!).resume()
         }
     }
 

--- a/Tests/NetworkMonitorFlowTests.swift
+++ b/Tests/NetworkMonitorFlowTests.swift
@@ -147,6 +147,13 @@ class NetworkMonitorFlowTests: NetworkMonitorUnitTests {
         super.setUp()
     }
 
+    override func tearDown() {
+
+        FNMNetworkMonitor.shared.configure(ignoredDomains: [])
+
+        super.tearDown()
+    }
+
     func testLiveRequestRecordsConcurrently() {
 
         XCTAssertNotNil(FNMNetworkMonitor.shared)
@@ -416,5 +423,20 @@ class NetworkMonitorFlowTests: NetworkMonitorUnitTests {
         XCTAssertFalse(self.networkMonitor.validate(profiles: profileResponsesDuplicated))
         XCTAssertTrue(self.networkMonitor.validate(profiles: profiles))
         XCTAssertTrue(self.networkMonitor.validate(profiles: profileResponsesEmpty))
+    }
+
+    func testIgnoredDomains() {
+
+        FNMNetworkMonitor.shared.configure(ignoredDomains: ["https://www.amazon.com"])
+
+        let robotsExpectation = expectation(description: "Some Robots")
+
+        self.reachSitesSequencially {
+
+            robotsExpectation.fulfill()
+            XCTAssertEqual(self.networkMonitor.records.count, Constants.Sites.allCases.count - 1)
+        }
+
+        waitForExpectations(timeout: 100, handler: { _ in })
     }
 }


### PR DESCRIPTION
# PR Details

## Description

Adds support for ignored domains, to allow ignore domains you don't care about debugging.  For example analytics. 

## Motivation and Context

Sometimes a lot of requests outside the main domain of the app are made, which might clutter the list of requests. For debugging we might not care at all about these domains, such as analytics for example. 

With this MR, we now give the client the ability to ignore these domains if he wishes to do so, cleaning up the list of requests. 

## How Has This Been Tested

Added a new api request to be made by the sample app. And add that domain to the list of ignored requests. That domain does not show up in the list of requests, as expected. If we remove it from the list, the requests start to show up again.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)