### PR TITLE
Added support for search with multiple keywords

### DIFF
--- a/FNMNetworkMonitor.podspec
+++ b/FNMNetworkMonitor.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
   spec.name = 'FNMNetworkMonitor'
   spec.module_name = 'FNMNetworkMonitor'
-  spec.version = '11.8.0'
+  spec.version = '11.9.0'
   spec.summary = 'A network monitor'
   spec.homepage = 'https://github.com/Farfetch/network-monitor-ios'
   spec.license = 'MIT'

--- a/NetworkMonitor/Classes/Debug/Controller/FNMDebugListingViewController.swift
+++ b/NetworkMonitor/Classes/Debug/Controller/FNMDebugListingViewController.swift
@@ -287,7 +287,7 @@ private extension FNMDebugListingViewController {
             guard let currentSearchFilters = self.currentSearchFilters(),
                   let requestUrl = $0.request.url?.absoluteString.lowercased() else { return true }
 
-            return currentSearchFilters.map { $0.lowercased() } .contains(where: requestUrl.contains)
+            return currentSearchFilters.contains(where: { requestUrl.contains($0.lowercased()) })
         }
 
         let errorFilter: RecordFilter = {

--- a/NetworkMonitor/Classes/Debug/Controller/FNMDebugListingViewController.swift
+++ b/NetworkMonitor/Classes/Debug/Controller/FNMDebugListingViewController.swift
@@ -253,9 +253,13 @@ private extension FNMDebugListingViewController {
         FNMNetworkMonitor.shared.subscribe(observer: self)
     }
 
-    func currentSearchFilter() -> String? {
+    func currentSearchFilters() -> [String]? {
 
-        return self.searchBar.text?.trimmingCharacters(in: .whitespacesAndNewlines) != "" ? self.searchBar.text : nil
+        guard let searchQuery = self.searchBar.text?.trimmingCharacters(in: .whitespacesAndNewlines), searchQuery != "" else { return nil }
+
+        let filters = searchQuery.components(separatedBy: " ")
+
+        return filters.count > 0 ? filters : nil
     }
 
     func updateStatus() {
@@ -280,8 +284,10 @@ private extension FNMDebugListingViewController {
         typealias RecordFilter = (FNMHTTPRequestRecord) -> Bool
 
         let searchFilter: RecordFilter = {
-            guard let currentSearchFilter = self.currentSearchFilter() else { return true }
-            return $0.request.url?.absoluteString.lowercased().contains(currentSearchFilter.lowercased()) == true
+            guard let currentSearchFilters = self.currentSearchFilters(),
+                  let requestUrl = $0.request.url?.absoluteString.lowercased() else { return true }
+
+            return currentSearchFilters.map { $0.lowercased() } .contains(where: requestUrl.contains)
         }
 
         let errorFilter: RecordFilter = {


### PR DESCRIPTION
# PR Details

Adds support for search with multiple keywords

## Related Issue

#22 

## Motivation and Context

Sometimes it's helpful to see multiple requests, that don't share a single keyword, at the same time. For instance, to check the order in which the requests are being made, etc.

## How Has This Been Tested

Linked this version to our app and used it to debug an issue with the order of distinct requests. Tried with single and multiple keywords.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)