### PR TITLE
Adds priority to FNMProfile

### DIFF
--- a/FNMNetworkMonitor.podspec
+++ b/FNMNetworkMonitor.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
   spec.name = 'FNMNetworkMonitor'
   spec.module_name = 'FNMNetworkMonitor'
-  spec.version = '11.9.0'
+  spec.version = '11.10.0'
   spec.summary = 'A network monitor'
   spec.homepage = 'https://github.com/Farfetch/network-monitor-ios'
   spec.license = 'MIT'

--- a/NetworkMonitor/Classes/Extension/FNMAdditions.swift
+++ b/NetworkMonitor/Classes/Extension/FNMAdditions.swift
@@ -230,7 +230,7 @@ extension NSURLRequest {
             return .noAvailableProfiles
         }
 
-        let individualProfileRequestMatchingResults = dataSource.availableProfiles().map { profile -> FNMProfile.ProfileRequestMatchingResult in return profile.matches(self) }
+        let individualProfileRequestMatchingResults = dataSource.availableProfiles(sorted: true).map { profile -> FNMProfile.ProfileRequestMatchingResult in return profile.matches(self) }
 
         let firstAvailableProfile = individualProfileRequestMatchingResults.compactMap { (result) -> FNMProfile? in
 

--- a/NetworkMonitor/Classes/FNMNetworkMonitor.swift
+++ b/NetworkMonitor/Classes/FNMNetworkMonitor.swift
@@ -317,9 +317,11 @@ extension FNMNetworkMonitor: FNMNetworkMonitorURLProtocolDataSource {
         }
     }
 
-    func availableProfiles() -> [FNMProfile] {
+    func availableProfiles(sorted: Bool = false) -> [FNMProfile] {
 
-        return self.profiles
+        return sorted
+        ? self.profiles.sorted { $0.priority < $1.priority }
+        : self.profiles
     }
 
     func availableProfileResponseAllowable() -> FNMProfileResponseAllowable {

--- a/NetworkMonitor/Classes/Profile/FNMProfile.swift
+++ b/NetworkMonitor/Classes/Profile/FNMProfile.swift
@@ -15,11 +15,17 @@ open class FNMProfile: NSObject, Codable {
     let request: FNMProfileRequest
     let responses: [FNMProfileResponse]
 
+    /// Priority is used as a tiebreaker when we have several possible profiles for the request made.
+    /// The profile with the highest priority (Uint.min [aka 0] being the highest value and UInt.max the lowest value) will be used.
+    let priority: UInt
+
     public required init(request: FNMProfileRequest,
-                         responses: [FNMProfileResponse]) {
+                         responses: [FNMProfileResponse],
+                         priority: UInt = UInt.min) {
 
         self.request = request
         self.responses = responses
+        self.priority = priority
     }
 
     convenience init?(record: FNMHTTPRequestRecord) {
@@ -70,6 +76,7 @@ open class FNMProfile: NSObject, Codable {
 
         case request
         case responses
+        case priority
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -77,6 +84,7 @@ open class FNMProfile: NSObject, Codable {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(self.request, forKey: .request)
         try container.encode(self.responses, forKey: .responses)
+        try container.encode(self.priority, forKey: .priority)
     }
 
     public convenience required init(from decoder: Decoder) throws {
@@ -85,8 +93,11 @@ open class FNMProfile: NSObject, Codable {
 
         do {
 
+            let priority = try values.decodeIfPresent(UInt.self, forKey: .priority) ?? UInt.min
+
             try self.init(request: values.decode(FNMProfileRequest.self, forKey: .request),
-                          responses: values.decode([FNMProfileResponse].self, forKey: .responses))
+                          responses: values.decode([FNMProfileResponse].self, forKey: .responses),
+                          priority: priority)
         }
     }
 }

--- a/NetworkMonitor/Classes/URLProtocol/FNMNetworkMonitorURLProtocol+Protocols.swift
+++ b/NetworkMonitor/Classes/URLProtocol/FNMNetworkMonitorURLProtocol+Protocols.swift
@@ -22,11 +22,19 @@ protocol FNMNetworkMonitorURLProtocolDataSourceRecord {
 
 protocol FNMNetworkMonitorURLProtocolDataSourceProfile {
 
-    func availableProfiles() -> [FNMProfile]
+    func availableProfiles(sorted: Bool) -> [FNMProfile]
 
     func availableProfileResponseAllowable() -> FNMProfileResponseAllowable
 
     func bumpUses(for profileResponseIdentifier: String)
+}
+
+extension FNMNetworkMonitorURLProtocolDataSourceProfile {
+
+    func availableProfiles(sorted: Bool = false) -> [FNMProfile] {
+
+        return self.availableProfiles(sorted: sorted)
+    }
 }
 
 protocol FNMNetworkMonitorURLProtocolDataSource: AnyObject, FNMNetworkMonitorURLProtocolDataSourceRecord, FNMNetworkMonitorURLProtocolDataSourceProfile { }

--- a/README.md
+++ b/README.md
@@ -70,6 +70,15 @@ FNMNetworkMonitor.shared.configure(ignoredDomains: ["somedomain.com"])
 
 This won't record nor intercept requests for this domain.
 
+You can also assign priority values to each profile, so that in case of a tie, the profile with the highest priority will be used.
+Priority is a UInt, being 0 the highest priority and UInt.max the lowest.
+
+```swift
+let request = FNMProfileRequest(urlPattern: .dynamicPattern(expression: "*farfetch.*robots"))
+let profiles = [FNMProfile(request: request,
+                           responses: [request.response(statusCode: 200)],
+                           priority: 123)]
+```
 
 
 Make sure to follow steps 1, 2 or 3, depending on the URLSession that runs that particular request.


### PR DESCRIPTION
# PR Details

Adds the possibility of having priorities associated with each `FNMProfile`.

![priorities](https://c.tenor.com/rHp04rpu-sYAAAAC/you-know-priorities.gif)

## Description

In situations where we have several profiles that match the request, the priority will serve as a tiebreaker.

## Motivation and Context

Currently, the profile chosen is the first to match, that is, the order in which the developer adds the profiles to the array will determine which profile is chosen. However, this approach is susceptible to errors, since at any time the developer can add new profiles, without remembering which profiles were already in the array and without remembering that another profile previously placed there will override the one he is adding now.
With this proposal, we allow each profile to have an associated priority, so the insertion order in the array is irrelevant and the developer has better control over the use of profiles.

## How Has This Been Tested

A wildcard profile was created where it catches all requests made to `https://*`, where we use the lowest priority for this profile.
Only when no other profile matches, is this profile used.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)