### PR TITLE
Adds new FNMHTTPMethod -> HEAD

### DIFF
--- a/FNMNetworkMonitor.podspec
+++ b/FNMNetworkMonitor.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
   spec.name = 'FNMNetworkMonitor'
   spec.module_name = 'FNMNetworkMonitor'
-  spec.version = '11.10.0'
+  spec.version = '11.11.0'
   spec.summary = 'A network monitor'
   spec.homepage = 'https://github.com/Farfetch/network-monitor-ios'
   spec.license = 'MIT'

--- a/NetworkMonitor/Classes/Profile/FNMProfile.swift
+++ b/NetworkMonitor/Classes/Profile/FNMProfile.swift
@@ -301,11 +301,12 @@ extension FNMRequestURLPattern: Equatable {
 
 public enum FNMHTTPMethod: String {
 
+    case delete = "DELETE"
     case get = "GET"
+    case head = "HEAD"
+    case patch = "PATCH"
     case post = "POST"
     case put = "PUT"
-    case delete = "DELETE"
-    case patch = "PATCH"
 
     func matches(httpMethodString: String) -> Bool {
 

--- a/Tests/NetworkMonitorFlowTests.swift
+++ b/Tests/NetworkMonitorFlowTests.swift
@@ -418,7 +418,7 @@ class NetworkMonitorFlowTests: NetworkMonitorUnitTests {
                                                                              filename: Constants.matchingProfiles1Filename)
         XCTAssertEqual(profiles.count, 3)
         XCTAssertEqual(profileResponsesDuplicated.count, 3)
-        XCTAssertEqual(profileResponsesEmpty.count, 4)
+        XCTAssertEqual(profileResponsesEmpty.count, 5)
 
         XCTAssertFalse(self.networkMonitor.validate(profiles: profileResponsesDuplicated))
         XCTAssertTrue(self.networkMonitor.validate(profiles: profiles))

--- a/Tests/NetworkMonitorProfileTests.swift
+++ b/Tests/NetworkMonitorProfileTests.swift
@@ -15,6 +15,7 @@ class NetworkMonitorProfileTests: NetworkMonitorUnitTests {
 
         static let repeatTastySecretiveYarnMuddledGET = "https://repeat.tasty.secretive.yarn/muddled/get"
         static let repeatTastySecretiveYarnMuddledPOST = "https://repeat.tasty.secretive.yarn/muddled/post"
+        static let repeatTastySecretiveYarnMuddledHEAD = "https://repeat.tasty.secretive.yarn/muddled/head"
         static let repeatTastySecretiveYarnMuddledCore = "repeat.tasty.secretive.yarn"
         static let balanceAbandonedGruesomeBreatheUseGET = "https://balance.abandoned.gruesome.breathe/use/get"
         static let balanceAbandonedGruesomeBreatheUsePOST = "https://balance.abandoned.gruesome.breathe/use/post"
@@ -26,6 +27,7 @@ class NetworkMonitorProfileTests: NetworkMonitorUnitTests {
 
         static let GET = "GET"
         static let POST = "POST"
+        static let HEAD = "HEAD"
 
         static let headerKeyNaco = "Naco"
         static let headerValuePimenta = "Pimenta"
@@ -184,7 +186,7 @@ class NetworkMonitorProfileTests: NetworkMonitorUnitTests {
         let profiles: [FNMProfile] = FNMProfile.decodedElements(from: Self.testBundle,
                                                                 filename: Constants.matchingProfiles1Filename)
 
-        XCTAssertEqual(profiles.count, 4)
+        XCTAssertEqual(profiles.count, 5)
 
         self.networkMonitor.configure(profiles: profiles)
 
@@ -256,6 +258,17 @@ class NetworkMonitorProfileTests: NetworkMonitorUnitTests {
                                        request: self.request(for: URLConstants.balanceAbandonedGruesomeBreatheUsePOST,
                                                                               httpMethod: URLConstants.POST))!.request.httpMethod,
                        .post)
+        
+        /// Right URL, Static, Right method, HEAD
+        XCTAssertEqual(self.firstMatch(profiles: profiles,
+                                       request: self.request(for: URLConstants.repeatTastySecretiveYarnMuddledHEAD,
+                                                             httpMethod: URLConstants.HEAD))!.request.urlPattern,
+                       FNMRequestURLPattern.staticPattern(url: URLConstants.repeatTastySecretiveYarnMuddledHEAD))
+        
+        XCTAssertEqual(self.firstMatch(profiles: profiles,
+                                       request: self.request(for: URLConstants.repeatTastySecretiveYarnMuddledHEAD,
+                                                             httpMethod: URLConstants.HEAD))!.request.httpMethod,
+                       .head)
     }
 
     func testProfileMatchingHeaders() {

--- a/Tests/Resources/Matching-Profiles-1.json
+++ b/Tests/Resources/Matching-Profiles-1.json
@@ -1,37 +1,47 @@
-[{
- "request": {
- "urlPattern": {
- "staticPattern": "https://repeat.tasty.secretive.yarn/muddled/get"
- },
- "httpMethod": "GET"
- },
- "responses": []
- },
- {
- "request": {
- "urlPattern": {
- "staticPattern": "https://repeat.tasty.secretive.yarn/muddled/post"
- },
- "httpMethod": "POST"
- },
- "responses": []
- },
- {
- "request": {
- "urlPattern": {
- "dynamicPattern": "^.*gruesome.breathe/use/get"
- },
- "httpMethod": "GET"
- },
- "responses": []
- },
- {
- "request": {
- "urlPattern": {
- "dynamicPattern": "^.*gruesome.breathe/use/post"
- },
- "httpMethod": "POST"
- },
- "responses": []
- }
- ]
+[
+    {
+        "request": {
+            "urlPattern": {
+                "staticPattern": "https://repeat.tasty.secretive.yarn/muddled/get"
+            },
+            "httpMethod": "GET"
+        },
+        "responses": []
+    },
+    {
+        "request": {
+            "urlPattern": {
+                "staticPattern": "https://repeat.tasty.secretive.yarn/muddled/post"
+            },
+            "httpMethod": "POST"
+        },
+        "responses": []
+    },
+    {
+        "request": {
+            "urlPattern": {
+                "dynamicPattern": "^.*gruesome.breathe/use/get"
+            },
+            "httpMethod": "GET"
+        },
+        "responses": []
+    },
+    {
+        "request": {
+            "urlPattern": {
+                "dynamicPattern": "^.*gruesome.breathe/use/post"
+            },
+            "httpMethod": "POST"
+        },
+        "responses": []
+    },
+    {
+        "request": {
+            "urlPattern": {
+                "staticPattern": "https://repeat.tasty.secretive.yarn/muddled/head"
+            },
+            "httpMethod": "HEAD"
+        },
+        "responses": []
+    }
+]


### PR DESCRIPTION
# PR Details

Adds new FNMHTTPMethod -> `HEAD`.

## Motivation and Context

The httpMethod `HEAD` is a commonly used and we didn't support it yet.

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)