### PR TITLE
Improves NetworkMonitor JSON Readability

### DIFF
--- a/FNMNetworkMonitor.podspec
+++ b/FNMNetworkMonitor.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |spec|
   spec.name = 'FNMNetworkMonitor'
   spec.module_name = 'FNMNetworkMonitor'
-  spec.version = '11.11.0'
+  spec.version = '11.11.1'
   spec.summary = 'A network monitor'
   spec.homepage = 'https://github.com/Farfetch/network-monitor-ios'
   spec.license = 'MIT'

--- a/NetworkMonitor/Classes/Debug/Model/FNMRecordDetailInfo.swift
+++ b/NetworkMonitor/Classes/Debug/Model/FNMRecordDetailInfo.swift
@@ -185,7 +185,7 @@ final class FNMRecordDetailInfo: Encodable {
             subtitle = "N/A"
         }
 
-        return Body(title: Constants.responseBodyTitle, contentType: .text(data: subtitle.unescaped))
+        return Body(title: Constants.responseBodyTitle, contentType: .text(data: subtitle))
     }
 }
 

--- a/NetworkMonitor/Classes/Debug/Model/FNMRecordDetailInfo.swift
+++ b/NetworkMonitor/Classes/Debug/Model/FNMRecordDetailInfo.swift
@@ -141,7 +141,7 @@ final class FNMRecordDetailInfo: Encodable {
             subtitle = "N/A"
         }
 
-        return Body(title: Constants.requestBodyTitle, contentType: .text(data: subtitle))
+        return Body(title: Constants.requestBodyTitle, contentType: .text(data: subtitle.unescaped))
     }
 
     static func responseBody(from record: FNMHTTPRequestRecord) -> Body {
@@ -185,7 +185,7 @@ final class FNMRecordDetailInfo: Encodable {
             subtitle = "N/A"
         }
 
-        return Body(title: Constants.responseBodyTitle, contentType: .text(data: subtitle))
+        return Body(title: Constants.responseBodyTitle, contentType: .text(data: subtitle.unescaped))
     }
 }
 

--- a/NetworkMonitor/Classes/Extension/FNMAdditions.swift
+++ b/NetworkMonitor/Classes/Extension/FNMAdditions.swift
@@ -131,6 +131,19 @@ public extension NSString {
     }
 }
 
+extension String {
+    
+    var unescaped: String {
+        
+        let entities = ["\t": "\\t", "\n": "\\n", "\r": "\\r"]
+
+        return entities.reduce(self) { string, entity in
+            
+            string.replacingOccurrences(of: entity.value, with: entity.key)
+        }
+    }
+}
+
 extension Dictionary where Key == String, Value == String {
 
     func contains(pair: (key: Key, value: Value)) -> Bool {

--- a/Tests/NetworkMonitorDebugUITests.swift
+++ b/Tests/NetworkMonitorDebugUITests.swift
@@ -86,4 +86,31 @@ class NetworkMonitorDebugUITests: NetworkMonitorUnitTests {
             }
         }
     }
+    
+    func testUnescapedStrings() {
+        
+        let newLine = "Some \n text."
+        let escapedNewLine = "Some \\n text."
+
+        XCTAssertEqual(newLine, newLine.unescaped)
+        XCTAssertEqual(escapedNewLine.unescaped, newLine)
+
+        let tab = "Some \t text."
+        let escapedTab = "Some \\t text."
+
+        XCTAssertEqual(tab, tab.unescaped)
+        XCTAssertEqual(escapedTab.unescaped, tab)
+
+        let carriageReturn = "Some \r text."
+        let escapedCarriageReturn = "Some \\r text."
+
+        XCTAssertEqual(carriageReturn, carriageReturn.unescaped)
+        XCTAssertEqual(escapedCarriageReturn.unescaped, carriageReturn)
+        
+        let multipleSpecialCharacters = "\n\t\tSome\t\ttext.\r"
+        let escapedMultipleSpecialCharacters = "\\n\\t\\tSome\\t\\ttext.\\r"
+        
+        XCTAssertEqual(multipleSpecialCharacters, multipleSpecialCharacters.unescaped)
+        XCTAssertEqual(escapedMultipleSpecialCharacters.unescaped, multipleSpecialCharacters)
+    }
 }

--- a/Tests/NetworkMonitorDebugUITests.swift
+++ b/Tests/NetworkMonitorDebugUITests.swift
@@ -112,5 +112,16 @@ class NetworkMonitorDebugUITests: NetworkMonitorUnitTests {
         
         XCTAssertEqual(multipleSpecialCharacters, multipleSpecialCharacters.unescaped)
         XCTAssertEqual(escapedMultipleSpecialCharacters.unescaped, multipleSpecialCharacters)
+        
+        let multipleSpecialCharactersData = multipleSpecialCharacters.data(using: .utf8)
+        let utf8String = String(data: multipleSpecialCharactersData ?? Data(), encoding: .utf8)
+        let base64Encoded = multipleSpecialCharactersData?.base64EncodedString()
+        
+        XCTAssertNotNil(multipleSpecialCharactersData)
+        XCTAssertNotNil(utf8String)
+        XCTAssertNotNil(base64Encoded)
+        
+        XCTAssertEqual(utf8String, utf8String?.unescaped)
+        XCTAssertEqual(base64Encoded, base64Encoded?.unescaped)
     }
 }


### PR DESCRIPTION
# PR Details

Improves NetworkMonitor Request Body JSON Readability

## Description

Adds a new String extension that will unescape some special characters therefore improving readability when presenting a given unescaped string.

## Motivation and Context

Be able to read the request JSON bodies in the debug monitor tools.

## Before

![Simulator Screen Shot - iPhone 14 Pro - 2023-01-17 at 11 24 25](https://user-images.githubusercontent.com/20420712/212886897-2f265638-58fd-41f0-849b-a633f7c0766b.png)

## After

![Simulator Screen Shot - iPhone 14 Pro - 2023-01-17 at 11 21 59](https://user-images.githubusercontent.com/20420712/212887004-89b3144f-3fb6-4d3b-8d2b-f519d26918a2.png)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)